### PR TITLE
Assert model is non null

### DIFF
--- a/lib/scoped_model.dart
+++ b/lib/scoped_model.dart
@@ -68,7 +68,7 @@ class ScopedModel<T extends Model> extends StatelessWidget {
   final Widget child;
 
   /// Constructor.
-  ScopedModel({this.model, this.child});
+  ScopedModel({this.model, this.child}) : assert(model != null);
 
   @override
   Widget build(BuildContext context) => new _ModelListener(


### PR DESCRIPTION
I add it here because I don't think it will go [into fuchsia](https://github.com/fuchsia-mirror/widgets/pull/1) anytime soon.

Without this assertion the app crashes with a cryptic error message when subscribing for changes. It should be impossible to create a scope with a `null` model to prevent such crashes early on.

### Before
```
The following NoSuchMethodError was thrown building ScopedModel<MyModel>:
The method 'addListener' was called on null.
Receiver: null
Tried calling: addListener(Closure: () => void from Function '_onChange@616019834':.)
```

### Now
```
The following assertion was thrown building SomeWidget(dirty, state: _SomeWidgetState#d0c78):
'package:myapp/model.dart': Failed assertion: line 78 pos 50: 'model != null': is not true.
```