### PR TITLE
Enhance `of` performance to O(1) from O(N) when rebuildOnChange is false

### DIFF
--- a/lib/scoped_model.dart
+++ b/lib/scoped_model.dart
@@ -175,7 +175,7 @@ class ScopedModel<T extends Model> extends StatelessWidget {
 
     Widget widget = rebuildOnChange
         ? context.inheritFromWidgetOfExactType(type)
-        : context.ancestorWidgetOfExactType(type);
+        : context.ancestorInheritedElementForWidgetOfExactType(type)?.widget;
 
     if (widget == null) {
       throw ScopedModelError();


### PR DESCRIPTION
Computational complexity of `static T of<T extends Model>` is O(1) when `rebuildOnChange` is true, but it degrades to O(N) when `rebuildOnChange` is false.

- O(1): [inheritFromWidgetOfExactType](https://docs.flutter.io/flutter/widgets/BuildContext/inheritFromWidgetOfExactType.html)
- O(N): [ancestorWidgetOfExactType](https://docs.flutter.io/flutter/widgets/BuildContext/ancestorWidgetOfExactType.html)

InheritedWidget can be accessed via [ancestorInheritedElementForWidgetOfExactType](https://docs.flutter.io/flutter/widgets/BuildContext/ancestorInheritedElementForWidgetOfExactType.html), whose computational complexity is O(1).

I think using `ancestorInheritedElementForWidgetOfExactType` is better than `ancestorWidgetOfExactType`.