### PR TITLE
Transition to using InheritedNotifier

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -17,8 +17,9 @@ class MyApp extends StatelessWidget {
     // At the top level of our app, we'll, create a ScopedModel Widget. This
     // will provide the CounterModel to all children in the app that request it
     // using a ScopedModelDescendant.
-    return ScopedModel<CounterModel>(
+    return ScopedModel(
       model: model,
+      tag: CounterTag(),
       child: MaterialApp(
         title: 'Scoped Model Demo',
         home: CounterHome('Scoped Model Demo'),
@@ -27,10 +28,12 @@ class MyApp extends StatelessWidget {
   }
 }
 
+class CounterTag extends DefaultTag {}
+
 // Start by creating a class that has a counter and a method to increment it.
 //
-// Note: It must extend from Model.
-class CounterModel extends Model {
+// Note: It must extend from ChangeNotifier.
+class CounterModel extends ChangeNotifier {
   int _counter = 0;
 
   int get counter => _counter;
@@ -64,7 +67,7 @@ class CounterHome extends StatelessWidget {
             // CounterModel from the nearest parent ScopedModel<CounterModel>.
             // It will hand that CounterModel to our builder method, and
             // rebuild any time the CounterModel changes (i.e. after we
-            // `notifyListeners` in the Model).
+            // `notifyListeners` in the ChangeNotifier).
             ScopedModelDescendant<CounterModel>(
               builder: (context, child, model) {
                 return Text(

--- a/example_async_and_test/lib/main.dart
+++ b/example_async_and_test/lib/main.dart
@@ -6,6 +6,8 @@ void main() {
   runApp(MyApp(model: CounterModel()));
 }
 
+class Distinct {}
+
 class MyApp extends StatelessWidget {
   final AbstractModel model;
 
@@ -16,7 +18,7 @@ class MyApp extends StatelessWidget {
     // At the top level of our app, we'll, create a ScopedModel Widget. This
     // will provide the CounterModel to all children in the app that request it
     // using a ScopedModelDescendant.
-    return ScopedModel<AbstractModel>(
+    return ScopedModel(
       model: model,
       child: MaterialApp(
         title: 'Flutter Demo',
@@ -31,8 +33,8 @@ class MyApp extends StatelessWidget {
 
 // Start by creating a class that has a counter and a method to increment it.
 //
-// Note: It must extend from Model.
-abstract class AbstractModel extends Model {
+// Note: It must extend from ChangeNotifier.
+abstract class AbstractModel extends ChangeNotifier {
   int get counter;
   void increment();
 }
@@ -87,7 +89,7 @@ class CounterHome extends StatelessWidget {
             // CounterModel from the nearest parent ScopedModel<CounterModel>.
             // It will hand that CounterModel to our builder method, and
             // rebuild any time the CounterModel changes (i.e. after we
-            // `notifyListeners` in the Model).
+            // `notifyListeners` in the ChangeNotifier).
             ScopedModelDescendant<AbstractModel>(
               builder: (context, child, model) => Text(
                 model.counter.toString(),

--- a/example_async_and_test/pubspec.yaml
+++ b/example_async_and_test/pubspec.yaml
@@ -2,7 +2,7 @@ name: example
 publish_to: none
 
 environment:
-  sdk: ">=2.12.0-0 <3.0.0"
+  sdk: ">=2.13.0-0 <3.0.0"
   flutter: ">=1.24.0-1.0.pre"
 
 dependencies:

--- a/lib/scoped_model.dart
+++ b/lib/scoped_model.dart
@@ -1,244 +1,102 @@
 library scoped_model;
 
-import 'dart:async';
-
 import 'package:flutter/material.dart';
 
-/// A base class that holds some data and allows other classes to listen to
-/// changes to that data.
-///
-/// In order to notify listeners that the data has changed, you must explicitly
-/// call the [notifyListeners] method.
-///
-/// Generally used in conjunction with a [ScopedModel] Widget, but if you do not
-/// need to pass the Widget down the tree, you can use a simple
-/// [AnimatedBuilder] to listen for changes and rebuild when the model notifies
-/// the listeners.
-///
-/// ### Example
-///
-/// ```
-/// class CounterModel extends Model {
-///   int _counter = 0;
-///
-///   int get counter => _counter;
-///
-///   void increment() {
-///     // First, increment the counter
-///     _counter++;
-///
-///     // Then notify all the listeners.
-///     notifyListeners();
-///   }
-/// }
-/// ```
-@deprecated
-abstract class Model extends Listenable {
-  final Set<VoidCallback> _listeners = Set<VoidCallback>();
-  int _version = 0;
-  int _microtaskVersion = 0;
-
-  /// [listener] will be invoked when the model changes.
-  @override
-  void addListener(VoidCallback listener) {
-    _listeners.add(listener);
-  }
-
-  /// [listener] will no longer be invoked when the model changes.
-  @override
-  void removeListener(VoidCallback listener) {
-    _listeners.remove(listener);
-  }
-
-  /// Returns the number of listeners listening to this model.
-  int get listenerCount => _listeners.length;
-
-  /// Should be called only by [Model] when the model has changed.
-  @protected
-  void notifyListeners() {
-    // We schedule a microtask to debounce multiple changes that can occur
-    // all at once.
-    if (_microtaskVersion == _version) {
-      _microtaskVersion++;
-      scheduleMicrotask(() {
-        _version++;
-        _microtaskVersion = _version;
-
-        // Convert the Set to a List before executing each listener. This
-        // prevents errors that can arise if a listener removes itself during
-        // invocation!
-        _listeners.toList().forEach((VoidCallback listener) => listener());
-      });
-    }
-  }
-}
-
-/// Finds a [Model]. Deprecated: Use [ScopedModel.of] instead.
-@deprecated
-class ModelFinder<T extends Model> {
-  /// Returns the [Model] of type [T] of the closest ancestor [ScopedModel].
-  ///
-  /// [Widget]s who call [of] with a [rebuildOnChange] of true will be rebuilt
-  /// whenever there's a change to the returned model.
-  T of(BuildContext context, {bool rebuildOnChange = false}) {
-    return ScopedModel.of<T>(context, rebuildOnChange: rebuildOnChange);
-  }
-}
-
-/// Provides a [Model] to all descendants of this Widget.
-///
-/// Descendant Widgets can access the model by using the
-/// [ScopedModelDescendant] Widget, which rebuilds each time the model changes,
-/// or directly via the [ScopedModel.of] static method.
-///
-/// To provide a Model to all screens, place the [ScopedModel] Widget above the
-/// [WidgetsApp] or [MaterialApp] in the Widget tree.
-///
-/// ### Example
-///
-/// ```
-/// ScopedModel<CounterModel>(
-///   model: CounterModel(),
-///   child: ScopedModelDescendant<CounterModel>(
-///     builder: (context, child, model) => Text(model.counter.toString()),
-///   ),
-/// );
-/// ```
-class ScopedModel<T extends Listenable> extends InheritedNotifier<T> {
-  /// The [Model] to provide to [child] and its descendants.
-  final T model;
-
-  /// The [Widget] the [model] will be available to.
-  ScopedModel({Key? key, required this.model, required Widget child})
+class ScopedModel<L extends Listenable, T extends DefaultTag>
+    extends InheritedNotifier<L> {
+  ScopedModel({Key? key, required this.model, this.tag, required Widget child})
       : super(key: key, notifier: model, child: child);
 
-  /// Finds a [Model] provided by a [ScopedModel] Widget.
-  ///
-  /// Generally, you'll use a [ScopedModelDescendant] to access a model in the
-  /// Widget tree and rebuild when the model changes. However, if you would to
-  /// access the model directly, you can use this function instead!
-  ///
-  /// ### Example
-  ///
-  /// ```
-  /// final model = ScopedModel.of<CounterModel>();
-  /// ```
-  ///
-  /// If you find yourself accessing your Model multiple times in this way, you
-  /// could also consider adding a convenience method to your own Models.
-  ///
-  /// ### Model Example
-  ///
-  /// ```
-  /// class CounterModel extends Model {
-  ///   static CounterModel of(BuildContext context) =>
-  ///       ScopedModel.of<CounterModel>(context);
-  /// }
-  ///
-  /// // Usage
-  /// final model = CounterModel.of(context);
-  /// ```
-  ///
-  /// ## Listening to multiple Models
-  ///
-  /// If you want a single Widget to rely on multiple models, you can use the
-  /// `of` method! No need to manage subscriptions, Flutter takes care of all
-  ///  of that through the magic of InheritedWidgets.
-  ///
-  /// ```
-  /// class CombinedWidget extends StatelessWidget {
-  ///   @override
-  ///   Widget build(BuildContext context) {
-  ///     final username =
-  ///       ScopedModel.of<UserModel>(context, rebuildOnChange: true).username;
-  ///     final counter =
-  ///       ScopedModel.of<CounterModel>(context, rebuildOnChange: true).counter;
-  ///
-  ///     return Text('$username tapped the button $counter times');
-  ///   }
-  /// }
-  /// ```
-  static T of<T extends Listenable>(BuildContext context,
+  final L model;
+  final T? tag;
+
+  static L of<L extends Listenable>(BuildContext context,
+      {bool rebuildOnChange = true}) {
+    return ofTagged<L, DefaultTag>(context, rebuildOnChange: rebuildOnChange);
+  }
+
+  static L ofTagged<L extends Listenable, T extends DefaultTag>(
+      BuildContext context,
       {bool rebuildOnChange = true}) {
     var widget = rebuildOnChange
-        ? context.dependOnInheritedWidgetOfExactType<ScopedModel<T>>()
+        ? context.dependOnInheritedWidgetOfExactType<ScopedModel<L, T>>()
         : context
-            .getElementForInheritedWidgetOfExactType<ScopedModel<T>>()
+            .getElementForInheritedWidgetOfExactType<ScopedModel<L, T>>()
             ?.widget;
 
     if (widget == null) {
       throw ScopedModelError();
     } else {
-      return (widget as ScopedModel<T>).model;
+      return (widget as ScopedModel<L, T>).model;
     }
   }
 }
 
-/// Builds a child for a [ScopedModelDescendant].
-typedef Widget ScopedModelDescendantBuilder<T extends Model>(
-  BuildContext context,
-  Widget? child,
-  T model,
-);
+class ScopedModelContainer extends StatelessWidget {
+  const ScopedModelContainer({required this.container, required this.child});
+  final List<Widget Function(Widget)> container;
+  final Widget child;
 
-/// Finds a specific [Model] provided by a [ScopedModel] Widget and rebuilds
-/// whenever the [Model] changes.
-///
-/// Provides an option to disable rebuilding when the [Model] changes.
-///
-/// Provide a constant [child] Widget if some portion inside the builder does
-/// not rely on the [Model] and should not be rebuilt.
-///
-/// ### Example
-///
-/// ```
-/// ScopedModel<CounterModel>(
-///   model: CounterModel(),
-///   child: ScopedModelDescendant<CounterModel>(
-///     child: Text('Button has been pressed:'),
-///     builder: (context, child, model) {
-///       return Column(
-///         children: [
-///           child,
-///           Text('${model.counter}'),
-///         ],
-///       );
-///     }
-///   ),
-/// );
-/// ```
-class ScopedModelDescendant<T extends Model> extends StatelessWidget {
-  /// Builds a Widget when the Widget is first created and whenever
-  /// the [Model] changes if [rebuildOnChange] is set to `true`.
-  final ScopedModelDescendantBuilder<T> builder;
+  @override
+  Widget build(BuildContext context) {
+    var wrapped = child;
 
-  /// An optional constant child that does not depend on the model.  This will
-  /// be passed as the child of [builder].
+    container.forEach((func) {
+      wrapped = func(wrapped);
+    });
+
+    return wrapped;
+  }
+}
+
+typedef ScopedModelDescendant<L extends Listenable>
+    = ScopedModelTagged<L, DefaultTag>;
+
+class ScopedModelTagged<L extends Listenable, T extends DefaultTag>
+    extends StatelessWidget {
+  ScopedModelTagged(
+      {required this.builder, this.child, this.rebuildOnChange = true});
+
+  final ScopedModelDescendantBuilder<L> builder;
   final Widget? child;
-
-  /// An optional value that determines whether the Widget will rebuild when
-  /// the model changes.
   final bool rebuildOnChange;
-
-  /// Creates the ScopedModelDescendant
-  ScopedModelDescendant({
-    required this.builder,
-    this.child,
-    this.rebuildOnChange = true,
-  });
 
   @override
   Widget build(BuildContext context) {
     return builder(
       context,
       child,
-      ScopedModel.of<T>(context, rebuildOnChange: rebuildOnChange),
+      ScopedModel.ofTagged<L, T>(context, rebuildOnChange: rebuildOnChange),
     );
   }
 }
 
-/// The error that will be thrown if the ScopedModel cannot be found in the
-/// Widget tree.
+typedef Widget ScopedModelDescendantBuilder<L extends Listenable>(
+  BuildContext context,
+  Widget? child,
+  L model,
+);
+
+extension OfContext on BuildContext {
+  L dependOn<L extends Listenable>() {
+    return ScopedModel.of<L>(this);
+  }
+
+  L dependOnTagged<L extends Listenable, T extends DefaultTag>() {
+    return ScopedModel.ofTagged<L, T>(this);
+  }
+
+  L get<L extends Listenable>() {
+    return ScopedModel.of<L>(this, rebuildOnChange: false);
+  }
+
+  L getTagged<L extends Listenable, T extends DefaultTag>() {
+    return ScopedModel.ofTagged<L, T>(this, rebuildOnChange: false);
+  }
+}
+
+abstract class DefaultTag {}
+
 class ScopedModelError extends Error {
   ScopedModelError();
 
@@ -247,7 +105,6 @@ class ScopedModelError extends Error {
     
 To fix, please:
           
-  * Provide types to ScopedModel<MyModel>
   * Provide types to ScopedModelDescendant<MyModel> 
   * Provide types to ScopedModel.of<MyModel>() 
   * Always use package imports. Ex: `import 'package:my_app/my_model.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ version: 2.0.0-nullsafety.0
 homepage: https://github.com/brianegan/scoped_model
 
 environment:
-  sdk: ">=2.12.0-0 <3.0.0"
+  sdk: ">=2.13.0-0 <3.0.0"
   flutter: ">=1.24.0-1.0.pre"
 
 dependencies:

--- a/test/scoped_model_test.dart
+++ b/test/scoped_model_test.dart
@@ -29,7 +29,7 @@ void main() {
     // Rebuild the widget
     await tester.pumpWidget(widget);
 
-    expect(model.listenerCount, 1);
+    expect(model.counter, 1);
     expect(find.text('1'), findsOneWidget);
   });
 
@@ -49,7 +49,7 @@ void main() {
     // Rebuild the widget
     await tester.pumpWidget(widget);
 
-    expect(model.listenerCount, 1);
+    expect(model.counter, 1);
     expect(find.text('$initialValue'), findsOneWidget);
   });
 
@@ -62,7 +62,7 @@ void main() {
 
     // build widget tree with items between scope and descendant
     var tree = MaterialApp(
-      home: ScopedModel<TestModel>(
+      home: ScopedModel(
         model: testModel,
         child: Container(
           child: BuildCountContainer(
@@ -107,7 +107,7 @@ void main() {
   });
 }
 
-class TestModel extends Model {
+class TestModel extends ChangeNotifier {
   int _counter;
 
   TestModel([int initialValue = 0]) : _counter = initialValue;
@@ -130,7 +130,7 @@ class TestWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return ScopedModel<TestModel>(
+    return ScopedModel(
       model: model,
       // Extra nesting to ensure the model is sent down the tree.
       child: Container(
@@ -158,7 +158,7 @@ class ErrorWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return ScopedModel<TestModel>(
+    return ScopedModel(
       model: model,
       // Extra nesting to ensure the model is sent down the tree.
       child: Container(


### PR DESCRIPTION
This PR deprecates the `Model` class and uses the built-in `InheritedNotifier` widget because it's now unnecessary to use all those widgets when we have a simple `InheritedNotifier` at our disposal.