### PR TITLE
1 line fix to example

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -69,7 +69,7 @@ class CounterHome extends StatelessWidget {
               builder: (context, child, model) {
                 return Text(
                   model.counter.toString(),
-                  style: Theme.of(context).textTheme.headline4,
+                  style: Theme.of(context).textTheme.headlineMedium,
                 );
               },
             ),


### PR DESCRIPTION
textTheme's headline4 is now headlineMedium since flutter 3.19+
re: https://docs.flutter.dev/release/breaking-changes/3-19-deprecations
tests pass with current stable flutter 3.24.1
